### PR TITLE
Prometheus node names

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ store:
 http:             
   port: 8079              # The port where the http server will listen on.
   address: "[::]"         # Optional listen address if you want the server to listen only on a specific interface
+
+prometheus:
+  namelabel: true         # Label prometheus node statistics with the host name
+  sitecodelabel: true     # Label prometheus node statistics with the received site code
 ```
 
 ## HTTP API

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -13,3 +13,7 @@ logger:
 http:
   port: 8080
   #address: "[::]"
+
+prometheus:
+  namelabel: true
+  sitecodelabel: true

--- a/src/github.com/dereulenspiegel/node-informant/gluon-collector/main.go
+++ b/src/github.com/dereulenspiegel/node-informant/gluon-collector/main.go
@@ -222,6 +222,7 @@ func main() {
 	Closeables = make([]io.Closer, 0, 5)
 	flag.Parse()
 	conf.InitConfig()
+	prometheus.Init()
 	if conf.Global == nil {
 		log.Fatal("Configuration couldn't be parsed")
 	}

--- a/src/github.com/dereulenspiegel/node-informant/gluon-collector/main_test.go
+++ b/src/github.com/dereulenspiegel/node-informant/gluon-collector/main_test.go
@@ -20,7 +20,7 @@ func TestCompletePipe(t *testing.T) {
 	graph := graphGenerator.GenerateGraph()
 	assert.NotNil(graph)
 	assert.Equal(169, len(graph.Batadv.Nodes))
-	assert.Equal(72, len(graph.Batadv.Links))
+	assert.Equal(71, len(graph.Batadv.Links))
 
 	nodes := nodesGenerator.GetNodesJson()
 	assert.NotNil(nodes)

--- a/src/github.com/dereulenspiegel/node-informant/gluon-collector/prometheus/pipes.go
+++ b/src/github.com/dereulenspiegel/node-informant/gluon-collector/prometheus/pipes.go
@@ -146,7 +146,7 @@ func getLabels(nodeinfo data.NodeInfo, defaultLabels ...string) []string {
 	if prometheusCfg.UBool("sitecodelabel", false) {
 		labels = append(labels, nodeinfo.System.SiteCode)
 	}
-	return labels
+	return append(labels, defaultLabels...)
 }
 
 func (n *NodeMetricCollector) Process(in chan data.ParsedResponse) chan data.ParsedResponse {

--- a/src/github.com/dereulenspiegel/node-informant/gluon-collector/prometheus/pipes_test.go
+++ b/src/github.com/dereulenspiegel/node-informant/gluon-collector/prometheus/pipes_test.go
@@ -1,0 +1,43 @@
+package prometheus
+
+import (
+	"testing"
+
+	"github.com/dereulenspiegel/node-informant/gluon-collector/config"
+	"github.com/dereulenspiegel/node-informant/gluon-collector/data"
+	cfg "github.com/olebedev/config"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testConfig = `
+  prometheus:
+    namelabel: true
+    sitecodelabel: true
+  `
+)
+
+func TestCreationOfPrometheusLabels(t *testing.T) {
+	assert := assert.New(t)
+	nodeinfo := data.NodeInfo{
+		Hostname: "Testnode",
+		System: data.SystemStruct{
+			SiteCode: "fftest",
+		},
+		NodeId: "1122",
+	}
+	var err error
+	config.Global, err = cfg.ParseYaml(testConfig)
+	assert.Nil(err)
+
+	prmcfg, err := config.Global.Get("prometheus")
+	assert.Nil(err)
+	assert.NotNil(prmcfg)
+
+	nodeLabels := getLabels(nodeinfo, "metric")
+	assert.Equal(4, len(nodeLabels))
+	assert.Equal("1122", nodeLabels[0])
+	assert.Equal("Testnode", nodeLabels[1])
+	assert.Equal("fftest", nodeLabels[2])
+	assert.Equal("metric", nodeLabels[3])
+}

--- a/src/github.com/dereulenspiegel/node-informant/gluon-collector/prometheus/prometheus.go
+++ b/src/github.com/dereulenspiegel/node-informant/gluon-collector/prometheus/prometheus.go
@@ -16,6 +16,30 @@ These are counters accumulated over all nodes. If possible these should be
 updated dynamically in ProcessPipes
 */
 var (
+	TotalClientCounter stat.Gauge
+
+	TotalNodes stat.Gauge
+
+	TotalNodeTrafficRx stat.Counter
+
+	TotalNodeTrafficTx stat.Counter
+
+	TotalNodeMgmtTrafficRx stat.Counter
+
+	TotalNodeMgmtTrafficTx stat.Counter
+
+	OnlineNodes stat.Gauge
+
+	NodesTrafficRx *stat.CounterVec
+
+	NodesTrafficTx *stat.CounterVec
+
+	NodesUptime *stat.CounterVec
+
+	NodesClients *stat.GaugeVec
+)
+
+func initPrometheusMetrics() {
 	TotalClientCounter = stat.NewGauge(stat.GaugeOpts{
 		Name: "total_clients",
 		Help: "Total number of connected clients",
@@ -70,16 +94,6 @@ var (
 		Name: "meshnode_clients",
 		Help: "Clients on single meshnodes",
 	}, nodeLabels)
-
-	NodeMetricsMap = make(map[string]*NodeMetrics)
-)
-
-// This type holds the Metrics for a single node
-type NodeMetrics struct {
-	Clients stat.Gauge
-	Uptime  stat.Counter
-	Traffic *stat.CounterVec
-	NodeId  string
 }
 
 func initNodeLabels() {
@@ -97,7 +111,11 @@ func initNodeLabels() {
 
 // Register all accumulated metrics
 func Init() {
+	if NodesTrafficRx != nil {
+		return
+	}
 	initNodeLabels()
+	initPrometheusMetrics()
 	stat.MustRegister(TotalClientCounter)
 	stat.MustRegister(TotalNodes)
 	stat.MustRegister(TotalNodeTrafficRx)

--- a/src/github.com/dereulenspiegel/node-informant/gluon-collector/prometheus/prometheus.go
+++ b/src/github.com/dereulenspiegel/node-informant/gluon-collector/prometheus/prometheus.go
@@ -2,8 +2,13 @@ package prometheus
 
 import (
 	log "github.com/Sirupsen/logrus"
+	"github.com/dereulenspiegel/node-informant/gluon-collector/config"
 	"github.com/dereulenspiegel/node-informant/gluon-collector/data"
 	stat "github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	nodeLabels = []string{"nodeid"}
 )
 
 /*
@@ -49,22 +54,22 @@ var (
 	NodesTrafficRx = stat.NewCounterVec(stat.CounterOpts{
 		Name: "meshnode_traffic_rx",
 		Help: "Transmitted traffic from nodes",
-	}, []string{"nodeid", "name", "type"})
+	}, append(nodeLabels, "type"))
 
 	NodesTrafficTx = stat.NewCounterVec(stat.CounterOpts{
 		Name: "meshnode_traffic_tx",
 		Help: "Received traffic on nodes",
-	}, []string{"nodeid", "name", "type"})
+	}, append(nodeLabels, "type"))
 
 	NodesUptime = stat.NewCounterVec(stat.CounterOpts{
 		Name: "meshnode_uptime",
 		Help: "Uptime of meshnodes",
-	}, []string{"nodeid", "name"})
+	}, nodeLabels)
 
 	NodesClients = stat.NewGaugeVec(stat.GaugeOpts{
 		Name: "meshnode_clients",
 		Help: "Clients on single meshnodes",
-	}, []string{"nodeid", "name"})
+	}, nodeLabels)
 
 	NodeMetricsMap = make(map[string]*NodeMetrics)
 )
@@ -77,8 +82,22 @@ type NodeMetrics struct {
 	NodeId  string
 }
 
+func initNodeLabels() {
+	prometheusCfg, err := config.Global.Get("prometheus")
+	if err != nil {
+		return
+	}
+	if prometheusCfg.UBool("namelabel", false) {
+		nodeLabels = append(nodeLabels, "hostname")
+	}
+	if prometheusCfg.UBool("sitecodelabel", false) {
+		nodeLabels = append(nodeLabels, "sitecode")
+	}
+}
+
 // Register all accumulated metrics
-func init() {
+func Init() {
+	initNodeLabels()
 	stat.MustRegister(TotalClientCounter)
 	stat.MustRegister(TotalNodes)
 	stat.MustRegister(TotalNodeTrafficRx)

--- a/src/github.com/dereulenspiegel/node-informant/gluon-collector/prometheus/prometheus.go
+++ b/src/github.com/dereulenspiegel/node-informant/gluon-collector/prometheus/prometheus.go
@@ -49,22 +49,22 @@ var (
 	NodesTrafficRx = stat.NewCounterVec(stat.CounterOpts{
 		Name: "meshnode_traffic_rx",
 		Help: "Transmitted traffic from nodes",
-	}, []string{"nodeid", "type"})
+	}, []string{"nodeid", "name", "type"})
 
 	NodesTrafficTx = stat.NewCounterVec(stat.CounterOpts{
 		Name: "meshnode_traffic_tx",
 		Help: "Received traffic on nodes",
-	}, []string{"nodeid", "type"})
+	}, []string{"nodeid", "name", "type"})
 
 	NodesUptime = stat.NewCounterVec(stat.CounterOpts{
 		Name: "meshnode_uptime",
 		Help: "Uptime of meshnodes",
-	}, []string{"nodeid"})
+	}, []string{"nodeid", "name"})
 
 	NodesClients = stat.NewGaugeVec(stat.GaugeOpts{
 		Name: "meshnode_clients",
 		Help: "Clients on single meshnodes",
-	}, []string{"nodeid"})
+	}, []string{"nodeid", "name"})
 
 	NodeMetricsMap = make(map[string]*NodeMetrics)
 )

--- a/src/github.com/dereulenspiegel/node-informant/gluon-collector/prometheus_pipes_test.go
+++ b/src/github.com/dereulenspiegel/node-informant/gluon-collector/prometheus_pipes_test.go
@@ -5,9 +5,11 @@ import (
 	"time"
 
 	"github.com/dereulenspiegel/node-informant/gluon-collector/collectors"
+	"github.com/dereulenspiegel/node-informant/gluon-collector/config"
 	"github.com/dereulenspiegel/node-informant/gluon-collector/data"
 	"github.com/dereulenspiegel/node-informant/gluon-collector/pipeline"
 	"github.com/dereulenspiegel/node-informant/gluon-collector/prometheus"
+	"github.com/dereulenspiegel/node-informant/gluon-collector/test"
 	stat "github.com/prometheus/client_golang/prometheus"
 
 	dto "github.com/prometheus/client_model/go"
@@ -84,4 +86,15 @@ func TestPrometheusClientCounter(t *testing.T) {
 	for range finishChan {
 		processPipeline.Close()
 	}
+}
+
+func TestPrometheusClientCounterWithFullLabels(t *testing.T) {
+	config.Global.Set("prometheus.namelabel", true)
+	config.Global.Set("prometheus.sitecodelabel", true)
+	store := data.NewSimpleInMemoryStore()
+	test.ExecuteCompletePipe(t, store)
+
+	// It is kinda complicated to collect values from CounterVecs,
+	// so for now this test simply makes sure that the application doesn't
+	// crash if extended node labels are activated.
 }

--- a/src/github.com/dereulenspiegel/node-informant/gluon-collector/test/test.go
+++ b/src/github.com/dereulenspiegel/node-informant/gluon-collector/test/test.go
@@ -12,10 +12,12 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	cfg "github.com/olebedev/config"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/dereulenspiegel/node-informant/announced"
 	"github.com/dereulenspiegel/node-informant/gluon-collector/assemble"
+	"github.com/dereulenspiegel/node-informant/gluon-collector/config"
 	"github.com/dereulenspiegel/node-informant/gluon-collector/data"
 	"github.com/dereulenspiegel/node-informant/utils"
 )
@@ -145,7 +147,12 @@ func LoadTestData() error {
 	return nil
 }
 
+func initDefaultConfig() {
+	config.Global = &cfg.Config{}
+}
+
 func init() {
+	initDefaultConfig()
 	err := LoadTestData()
 	if err != nil {
 		log.Fatalf("Can't load test data: %v", err)

--- a/src/github.com/dereulenspiegel/node-informant/gluon-collector/test/test.go
+++ b/src/github.com/dereulenspiegel/node-informant/gluon-collector/test/test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dereulenspiegel/node-informant/gluon-collector/assemble"
 	"github.com/dereulenspiegel/node-informant/gluon-collector/config"
 	"github.com/dereulenspiegel/node-informant/gluon-collector/data"
+	"github.com/dereulenspiegel/node-informant/gluon-collector/prometheus"
 	"github.com/dereulenspiegel/node-informant/utils"
 )
 
@@ -49,6 +50,7 @@ func (t *TestDataReceiver) Close() error {
 
 func ExecuteCompletePipe(t *testing.T, store data.Nodeinfostore) {
 	log.SetLevel(log.ErrorLevel)
+	prometheus.Init()
 	assert := assert.New(t)
 	testReceiver := &TestDataReceiver{TestData: TestData}
 


### PR DESCRIPTION
This PR enables additional labels on prometheus metrics to be able to filter statistics by nodes hostname and sitecode. This closes issue #9 
