### PR TITLE
Fixed gluon-collector crash if config is not valid

### DIFF
--- a/gluon-collector/main.go
+++ b/gluon-collector/main.go
@@ -222,10 +222,10 @@ func main() {
 	Closeables = make([]io.Closer, 0, 5)
 	flag.Parse()
 	conf.InitConfig()
-	prometheus.Init()
 	if conf.Global == nil {
 		log.Fatal("Configuration couldn't be parsed")
 	}
+	prometheus.Init()
 	ConfigureLogger()
 	CreateDataStore()
 	prometheus.ProcessStoredValues(DataStore)


### PR DESCRIPTION
gluon-collector would crash if the config could not be loaded. The cause of this is an access to config.Get('prometheus') without actually checking if the config is loaded before initializing prometheus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ffdo/node-informant/29)
<!-- Reviewable:end -->
